### PR TITLE
docs: codify delivery workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -11,6 +11,7 @@ assignees: alucero270
 
 What needs to be done?
 Keep this short and concrete.
+This issue should describe exactly one reviewable change.
 
 ---
 
@@ -25,6 +26,8 @@ Keep this short and concrete.
   - `path/to/file.cs`
   - `ops/docker-compose.yml`
 
+Keep the scope narrow. Do not combine unrelated work in one issue.
+
 ---
 
 ## Acceptance Criteria
@@ -36,6 +39,7 @@ What must exist or be true for this to be considered done?
 - [ ] Condition 3
 
 All criteria must be objectively verifiable.
+The issue should be closable by one pull request.
 
 ---
 

--- a/contributing.md
+++ b/contributing.md
@@ -107,18 +107,48 @@ BREAKING CHANGE:
 # Branching Strategy
 
 - One branch per issue
-- Branch name format: `issue/<number>-short-description`
+- Branch name format: `feature/<number>-short-description`
 - Merge via Pull Request
 - Squash only if commits are noisy
 - Do not push directly to `main`
 
 # Issue Workflow
 
-Every change should map to a single GitHub issue with:
+Every change starts from exactly one GitHub issue.
+
+The issue must stay narrowly scoped and include:
 
 - Summary
 - Scope
 - Acceptance Criteria
 - Notes (optional)
 
-Keep pull requests small, reviewable, and aligned to one issue at a time.
+Do not bundle unrelated work under one issue. If the work splits into multiple
+independent changes, create separate issues and branches.
+
+## Delivery Flow
+
+Use the following workflow for every contribution:
+
+1. Create or choose one GitHub issue.
+2. Confirm the issue stays narrow enough to review in one pull request.
+3. Branch from `main` using `feature/<number>-short-description`.
+4. Implement only the work required for that issue.
+5. Run the smallest relevant local validation before pushing.
+6. Push the branch and open a pull request against `main`.
+7. Reference the issue in the pull request and commit footer using
+   `Closes #<number>` when the change completes the issue.
+
+## Pull Request Expectations
+
+Every pull request should map to a single GitHub issue and should remain small,
+reviewable, and honest about what is implemented now versus what is only
+roadmap work.
+
+Pull requests should:
+
+- summarize what changed
+- explain why it changed
+- list the validation used
+- call out follow-up work separately instead of bundling it
+- avoid overstating readiness, feature completeness, or future roadmap items


### PR DESCRIPTION
## Summary
- update `contributing.md` to document the full issue -> branch -> validation -> PR flow
- align branch naming with `feature/<number>-short-description`
- tighten the issue template so issues stay narrow and closable by one pull request

## Why
Issue #35 asks for the repo's delivery workflow to be explicit and issue-first. This change keeps the scope process-focused and makes the expected branch, validation, and PR discipline visible in the repo itself.

## Validation
- `git diff --check`
- verified updated workflow docs and issue template formatting locally

Closes #35