### PR TITLE
fix: restore web build tool resolution

### DIFF
--- a/src/Codex.Web/package.json
+++ b/src/Codex.Web/package.json
@@ -4,9 +4,10 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc --noEmit && vite build",
-    "preview": "vite preview"
+    "dev": "npm exec vite",
+    "typecheck": "npm exec tsc -- --noEmit",
+    "build": "npm run typecheck && npm exec vite build",
+    "preview": "npm exec vite preview"
   },
   "dependencies": {
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- update the web npm scripts to execute local TypeScript and Vite binaries through `npm exec`
- add an explicit `typecheck` script and make `build` depend on it
- keep the fix limited to frontend build-tool resolution with no product behavior changes

## Why
Issue #25 tracks a clean-checkout failure where `npm install` completed but `npm run build` could not resolve `tsc` on Windows. This change keeps the build path tied to the locally installed toolchain instead of shell PATH behavior.

## Validation
- `npm install` in `src/Codex.Web`
- `npm run build` in `src/Codex.Web`

Closes #25