### PR TITLE
feat(api): add health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Planned or still maturing:
 - first-class multi-source modeling and source management APIs
 - stronger runtime boundary hardening, including symlink escape protection
 - richer retrieval metadata, filtering, and pagination
-- health endpoints, broader verification coverage, and more complete operator runbooks
+- broader verification coverage and more complete operator runbooks
 - optional AI enhancement, additional connectors, and multi-user access control
 
 ## Architecture
@@ -92,7 +92,7 @@ docker compose -f ops/docker-compose.yml --env-file .env up -d --build
 ```
 
 5. Apply the SQL migrations described in [`docs/operations.md`](docs/operations.md).
-6. Verify the stack and smoke-test retrieval using the commands in [`docs/operations.md`](docs/operations.md).
+6. Verify API readiness at `/health` and smoke-test retrieval using the commands in [`docs/operations.md`](docs/operations.md).
 
 ## Documentation
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,6 +4,18 @@
 
 Strata currently exposes a small HTTP API for indexing and retrieval.
 
+## `GET /health`
+
+Return a minimal readiness response for API boot verification.
+
+### Response
+
+```json
+{
+  "status": "ok"
+}
+```
+
 ## `POST /api/search`
 
 Search indexed documents using PostgreSQL full-text search.
@@ -98,4 +110,6 @@ Fetch the current status of an indexing job.
 
 - The current repository still exposes `/weatherforecast` as a temporary
   development endpoint, but it is not part of the Strata product contract
+- Use `/health` for basic readiness checks instead of temporary development
+  endpoints
 - All API behavior remains valid without optional AI services enabled

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -97,6 +97,12 @@ docker compose -f ops/docker-compose.yml --env-file .env ps
 docker compose -f ops/docker-compose.yml --env-file .env logs --tail 100
 ```
 
+Verify API readiness:
+
+```powershell
+Invoke-WebRequest -Uri http://localhost:8080/health
+```
+
 Smoke-test search:
 
 ```powershell
@@ -126,7 +132,7 @@ This validation entry point runs:
 - `dotnet build Codex.slnx`
 - `npm install` and `npm run build` in `src/Codex.Web`
 - `docker compose ... config` against the repository-root `.env`
-- a local API boot probe against the current development OpenAPI endpoint
+- a local API boot probe against `GET /health`
 
 ## Web Shell
 
@@ -153,6 +159,13 @@ npm run build
 Set `NEXT_PUBLIC_STRATA_API_BASE_URL` to the Strata API origin you want the web
 shell to call. This remains an explicit API endpoint setting and does not
 change Strata's source-boundary model.
+
+Web-to-API connectivity check:
+
+- confirm `NEXT_PUBLIC_STRATA_API_BASE_URL` points to the same API origin that
+  returns `200 OK` from `/health`
+- after the web shell starts, run a search and confirm the browser can reach
+  `POST /api/search` on that API origin without network or CORS errors
 
 ## Operational Notes
 

--- a/ops/validate-platform-readiness.ps1
+++ b/ops/validate-platform-readiness.ps1
@@ -13,6 +13,17 @@ function Invoke-Step {
     Write-Host "OK: $Name" -ForegroundColor Green
 }
 
+function Assert-LastExitCode {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Message Exit code: $LASTEXITCODE."
+    }
+}
+
 function Get-FreeTcpPort {
     $listener = [System.Net.Sockets.TcpListener]::new(
         [System.Net.IPAddress]::Loopback,
@@ -92,7 +103,7 @@ function Test-ApiReadiness {
                 break
             }
 
-            & curl.exe --fail --silent --show-error "$apiUrl/openapi/v1.json" > $null
+            & curl.exe --fail --silent --show-error "$apiUrl/health" > $null
             if ($LASTEXITCODE -eq 0) {
                 $ready = $true
                 break
@@ -107,7 +118,7 @@ function Test-ApiReadiness {
             if (Test-Path $stderrLog) {
                 Get-Content $stderrLog
             }
-            throw "API readiness probe did not succeed at $apiUrl/openapi/v1.json."
+            throw "API readiness probe did not succeed at $apiUrl/health."
         }
     }
     finally {
@@ -130,12 +141,14 @@ Push-Location $repoRoot
 try {
     Invoke-Step "Build .NET solution" {
         dotnet build Codex.slnx
+        Assert-LastExitCode "dotnet build failed."
     }
 
     Invoke-Step "Install web dependencies" {
         Push-Location $webRoot
         try {
             npm install
+            Assert-LastExitCode "npm install failed."
         }
         finally {
             Pop-Location
@@ -146,6 +159,7 @@ try {
         Push-Location $webRoot
         try {
             npm run build
+            Assert-LastExitCode "npm run build failed."
         }
         finally {
             Pop-Location
@@ -158,6 +172,7 @@ try {
         }
 
         docker compose -f $composeFile --env-file $envFile config > $null
+        Assert-LastExitCode "docker compose config failed."
     }
 
     Invoke-Step "Probe API readiness" {

--- a/src/Codex.Api/Controllers/HealthController.cs
+++ b/src/Codex.Api/Controllers/HealthController.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Codex.Api.Controllers;
+
+[ApiController]
+[Route("health")]
+public sealed class HealthController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get()
+    {
+        return Ok(new
+        {
+            status = "ok"
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `GET /health` endpoint for basic API readiness checks
- switch platform readiness validation to probe `/health` instead of temporary development endpoints
- document API boot verification and web-to-API connectivity checks

## Why
Issue #27 closes a verification gap in the current Milestone 1 platform-readiness work. Strata needed a stable, product-facing readiness path instead of relying on temporary development endpoints for local verification.

## Validation
- `dotnet build Codex.slnx`
- `powershell -ExecutionPolicy Bypass -File ops/validate-platform-readiness.ps1`
- `git diff --check`

Closes #27