### PR TITLE
chore(ops): make embedder optional in compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ STRATA_DB_CONNECTION=
 
 STRATA_SOURCES=
 
+# Optional AI enhancement settings. Leave blank unless you enable the AI
+# profile for the embedder service.
 STRATA_EMBED_PROVIDER=
 STRATA_EMBED_MODEL=
 

--- a/README.md
+++ b/README.md
@@ -84,11 +84,19 @@ Planned expansion follows the milestone roadmap in
 
 1. Copy `.env.example` to `.env`.
 2. Set `STRATA_SOURCES` to a readable host directory that Strata is allowed to ingest.
-3. Review `POSTGRES_*`, `STRATA_DB_CONNECTION`, `STRATA_API_PORT`, and optional embedding settings.
+3. Review `POSTGRES_*`, `STRATA_DB_CONNECTION`, `STRATA_API_PORT`, and optional embedding settings if you plan to enable AI enhancement services.
 4. Start the stack:
 
 ```powershell
 docker compose -f ops/docker-compose.yml --env-file .env up -d --build
+```
+
+This default path starts the core retrieval stack without the embedder.
+
+Optional AI enhancement services:
+
+```powershell
+docker compose -f ops/docker-compose.yml --env-file .env --profile ai up -d --build
 ```
 
 5. Apply the SQL migrations described in [`docs/operations.md`](docs/operations.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,8 @@ boundary, PostgreSQL-backed indexing, and API-first document access.
 ### Optional Enhancement Layer
 
 - Embedder worker and Ollama profile remain optional
+- Docker Compose keeps the embedder and local Ollama runtime off by default
+  unless the `ai` profile is enabled
 - Search and document retrieval continue to function without them
 - AI is a downstream enhancement layer, not a core dependency
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -17,6 +17,9 @@ Key variables:
 - `STRATA_EMBED_MODEL`
 - `STRATA_LOG_LEVEL`
 
+`STRATA_EMBED_PROVIDER` and `STRATA_EMBED_MODEL` are optional. Leave them blank
+unless you plan to run the AI enhancement profile.
+
 `.env` is for operator convenience. It is not secure secret storage and should
 not be treated as a production secret-management solution.
 
@@ -55,11 +58,18 @@ Copy-Item .env.example .env
 docker compose -f ops/docker-compose.yml --env-file .env up -d --build
 ```
 
-Optional AI services:
+This default command starts the core Strata stack: PostgreSQL, API, and
+indexer.
+
+Optional AI enhancement services:
 
 ```powershell
-docker compose -f ops/docker-compose.yml --env-file .env --profile ollama up -d
+docker compose -f ops/docker-compose.yml --env-file .env --profile ai up -d --build
 ```
+
+The `ai` profile adds the embedder worker and the local Ollama runtime. Leave
+that profile disabled when you only need baseline full-text ingestion and
+retrieval.
 
 Stop the stack:
 
@@ -158,5 +168,6 @@ change Strata's source-boundary model.
 
 - The current codebase still uses internal `Codex.*` runtime identifiers in some
   places; Docker and docs now present the Strata product surface
-- The embedder and Ollama profile are optional enhancements
+- The embedder and Ollama services are default-off optional enhancements in
+  Compose
 - Read-only source mounting is part of Strata's trust model

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -89,6 +89,7 @@ services:
 
   strata-embedder:
     container_name: strata-embedder
+    profiles: ["ai"]
     build:
       context: ..
       dockerfile: ops/Dockerfile.embedder
@@ -125,7 +126,7 @@ services:
   ollama:
     image: ollama/ollama:latest
     container_name: strata-ollama
-    profiles: ["ollama"]
+    profiles: ["ai", "ollama"]
     restart: unless-stopped
     ports:
       - "${STRATA_OLLAMA_PORT:-11434}:11434"


### PR DESCRIPTION
## Summary
- make the embedder worker opt-in through a dedicated Compose `ai` profile
- keep the default Compose path focused on the core PostgreSQL, API, and indexer stack
- update README, operations docs, architecture notes, and `.env.example` so the AI-optional deployment path is explicit

## Why
Issue #101 closes the gap between Strata's documented AI-optional product position and the current default runtime behavior. The core full-text ingestion and retrieval path should be easy to run without the embedder service.

## Validation
- `docker compose -f ops/docker-compose.yml --env-file .env config --services`
- `docker compose -f ops/docker-compose.yml --env-file .env --profile ai config --services`
- `git diff --check`

Closes #101