### PR TITLE
chore(ci): add GitHub Actions validation workflow

### DIFF
--- a/.github/workflows/validate-platform-readiness.yml
+++ b/.github/workflows/validate-platform-readiness.yml
@@ -1,0 +1,105 @@
+name: Validate Platform Readiness
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: src/Codex.Web/package-lock.json
+
+      - name: Create CI configuration files
+        shell: bash
+        run: |
+          cat > .env <<EOF
+          POSTGRES_USER=strata
+          POSTGRES_PASSWORD=strata
+          POSTGRES_DB=strata
+          POSTGRES_PORT=5432
+          STRATA_API_PORT=8080
+          STRATA_DB_CONNECTION=Host=localhost;Port=5432;Database=strata;Username=strata;Password=strata
+          STRATA_SOURCES=${GITHUB_WORKSPACE}/docs
+          STRATA_EMBED_PROVIDER=
+          STRATA_EMBED_MODEL=
+          STRATA_LOG_LEVEL=Information
+          EOF
+
+          cat > src/Codex.Web/.env.local <<EOF
+          NEXT_PUBLIC_STRATA_API_BASE_URL=http://127.0.0.1:8080
+          EOF
+
+      - name: Build .NET solution
+        run: dotnet build Codex.slnx
+
+      - name: Install web dependencies
+        working-directory: src/Codex.Web
+        run: npm install
+
+      - name: Build web shell
+        working-directory: src/Codex.Web
+        run: npm run build
+
+      - name: Validate Docker Compose configuration
+        run: docker compose -f ops/docker-compose.yml --env-file .env config > /dev/null
+
+      - name: Probe API readiness
+        shell: bash
+        env:
+          ASPNETCORE_ENVIRONMENT: Development
+          ASPNETCORE_URLS: http://127.0.0.1:5180
+          Codex__DocsRootPath: ${{ github.workspace }}/docs
+          ConnectionStrings__Default: Host=localhost;Port=5432;Database=strata;Username=strata;Password=strata
+        run: |
+          dotnet run --project src/Codex.Api/Codex.Api.csproj --no-build --no-launch-profile > api.log 2>&1 &
+          api_pid=$!
+
+          cleanup() {
+            if kill -0 "$api_pid" 2>/dev/null; then
+              kill "$api_pid"
+              wait "$api_pid" || true
+            fi
+          }
+
+          trap cleanup EXIT
+
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent http://127.0.0.1:5180/health > /dev/null; then
+              break
+            fi
+
+            if ! kill -0 "$api_pid" 2>/dev/null; then
+              cat api.log
+              exit 1
+            fi
+
+            sleep 2
+          done
+
+          curl --fail --silent http://127.0.0.1:5180/health > /dev/null
+
+          if ! curl --silent http://127.0.0.1:5180/openapi/v1.json | grep -q '"/health"'; then
+            cat api.log
+            echo "OpenAPI is missing /health."
+            exit 1
+          fi

--- a/.github/workflows/validate-platform-readiness.yml
+++ b/.github/workflows/validate-platform-readiness.yml
@@ -98,8 +98,8 @@ jobs:
 
           curl --fail --silent http://127.0.0.1:5180/health > /dev/null
 
-          if ! curl --silent http://127.0.0.1:5180/openapi/v1.json | grep -q '"/health"'; then
+          if ! curl --fail --silent http://127.0.0.1:5180/openapi/v1.json > /dev/null; then
             cat api.log
-            echo "OpenAPI is missing /health."
+            echo "OpenAPI endpoint did not return a successful response."
             exit 1
           fi

--- a/.github/workflows/validate-platform-readiness.yml
+++ b/.github/workflows/validate-platform-readiness.yml
@@ -83,7 +83,7 @@ jobs:
 
           trap cleanup EXIT
 
-          for attempt in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if curl --fail --silent http://127.0.0.1:5180/health > /dev/null; then
               break
             fi

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -144,6 +144,10 @@ This validation entry point runs:
 - `docker compose ... config` against the repository-root `.env`
 - a local API boot probe against `GET /health`
 
+GitHub Actions runs the same baseline validation on pull requests and pushes to
+`main` through
+`.github/workflows/validate-platform-readiness.yml`.
+
 ## Web Shell
 
 The current web shell runs on Next.js and continues to call the Strata API


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that validates the current platform-readiness baseline on pull requests and pushes to `main`
- run the repo's existing .NET build, web build, Docker Compose config, and API health checks in CI
- document the workflow location in the operations guide

## Why
Issue #113 adds CI coverage for the Strata baseline without pretending there is deployment automation in place yet. This keeps the repo honest: CI is now automated, while CD remains a separate future concern tied to a real deployment target.

## Validation
- `dotnet build Codex.slnx`
- `npm install` in `src/Codex.Web`
- `npm run build` in `src/Codex.Web`
- `docker compose -f ops/docker-compose.yml --env-file .env.ci config`
- live API readiness check confirming `/health` and `/openapi/v1.json`
- `git diff --check`

## Notes
- I could not run `actionlint` in this local session because Docker was unavailable
- the workflow is CI-only; no deployment automation is introduced here

Closes #113