### PR TITLE
docs(ops): add platform readiness checklist

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -100,6 +100,48 @@ to match.
 
 ## Verification
 
+### Platform Readiness Checklist
+
+Use this checklist before treating a local or development deployment as ready
+for Milestone 2 ingestion work.
+
+Everything below must pass:
+
+- configuration sanity:
+  `.env` exists at the repository root, `STRATA_DB_CONNECTION` is set, and
+  `STRATA_SOURCES` points to an existing host directory intended for ingestion
+- source-boundary sanity:
+  the configured `STRATA_SOURCES` directory contains only intended content, and
+  Compose will mount that path read-only into the API and indexer services
+- backend build:
+  `dotnet build Codex.slnx` succeeds without project or solution errors
+- web build:
+  in `src/Codex.Web`, `npm install` and `npm run build` both succeed
+- Compose config:
+  `docker compose -f ops/docker-compose.yml --env-file .env config` succeeds
+- API readiness:
+  `GET /health` returns `200 OK` after the API starts
+- retrieval smoke test:
+  `POST /api/search` returns a successful response with the configured API
+- source path sanity:
+  the running stack can start with the configured source path mounted at the
+  same host path and without broader filesystem access
+- web-to-API sanity:
+  when the web shell is used, it can reach the configured API origin without
+  browser network or CORS errors
+
+Recommended command path:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File ops/validate-platform-readiness.ps1
+```
+
+Then run the source-path and smoke-test checks in this document against your
+actual `.env` values.
+
+Milestone 1 should not be considered complete for a local or development
+environment unless every checklist item above passes.
+
 Check stack health:
 
 ```powershell


### PR DESCRIPTION
## Summary
- add a platform-readiness checklist to the operations guide
- turn the existing build, Compose, API health, and smoke-test steps into an explicit Milestone 1 gate
- keep the checklist aligned to the repo's actual runnable validation commands

## Why
Issue #38 asks for a concise readiness checklist that a developer can use before Milestone 2 work begins. This change keeps the scope docs-only and makes the current verification expectations explicit instead of implied across multiple sections.

## Validation
- `git diff --check`
- reviewed the checklist against the existing validation script and operations commands

Closes #38