### PR TITLE
docs(repo): tighten contribution workflow

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -132,12 +132,16 @@ Use the following workflow for every contribution:
 
 1. Create or choose one GitHub issue.
 2. Confirm the issue stays narrow enough to review in one pull request.
-3. Branch from `main` using `feature/<number>-short-description`.
-4. Implement only the work required for that issue.
-5. Run the smallest relevant local validation before pushing.
-6. Push the branch and open a pull request against `main`.
-7. Reference the issue in the pull request and commit footer using
+3. Update local `main` from `origin/main` so the issue branch starts from the
+   current mainline state.
+4. Branch from `main` using `feature/<number>-short-description`.
+5. Implement only the work required for that issue.
+6. Run the smallest relevant local validation before pushing.
+7. Push the branch and open a pull request against `main`.
+8. Reference the issue in the pull request and commit footer using
    `Closes #<number>` when the change completes the issue.
+9. After the pull request merges, confirm the issue is closed and delete the
+   completed branch locally and on GitHub.
 
 ## Pull Request Expectations
 


### PR DESCRIPTION
## Summary
- update the contribution workflow to require syncing local `main` from `origin/main` before starting issue work
- add explicit post-merge branch cleanup guidance
- keep the change limited to contribution guidance in `contributing.md`

## Why
Issue #118 tightens the repo workflow so the documented process matches how we want contributors to work: start from current mainline state, then clean up the issue branch once the work is merged.

## Validation
- `git diff --check`

Closes #118