### PR TITLE
docs(architecture): formalize source-boundary rules

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,15 +68,35 @@ boundary, PostgreSQL-backed indexing, and API-first document access.
 Strata's architecture assumes all ingestion is anchored to configured source
 roots and never to user-supplied filesystem paths.
 
+### Boundary Model
+
+- The configured `STRATA_SOURCES` value defines the only trusted filesystem
+  starting point for ingestion in a given deployment
+- The API, indexer, and operator workflows must treat any path outside that root
+  as out of bounds
+- Stored document identity is relative to the declared root, not to arbitrary
+  host paths
+- Requests may trigger ingestion work, but they must not supply or redefine the
+  filesystem scope of that work
+
 ### Required Rules
 
 - The configured root must exist before ingestion starts
+- The configured root must be explicit server-side configuration, never a
+  client-selected path
 - Stored document paths must remain relative to that root
 - Boundary checks must prevent traversal outside declared roots
+- Filesystem indirection such as symlinks or reparse points must not expand the
+  effective boundary beyond the declared root
 - Read-only mounts are the default deployment mode
+- When enforcement cannot prove a path remains in bounds, the system should fail
+  closed for that path instead of widening access
 
 ### Current Foundation
 
 - Compose mounts the configured source path read-only
 - API and indexer receive the root path from configuration only
 - Indexed document paths are normalized relative paths
+- The current foundation establishes the boundary contract now, while deeper
+  hardening and verification remain follow-on work rather than implied current
+  guarantees

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -47,6 +47,8 @@ Operational expectation:
 - The directory must exist before the stack starts
 - The directory should contain only content intended for ingestion
 - Strata should not be granted broader filesystem access than necessary
+- Operators should treat the configured path as a trust boundary, not as a
+  convenience pointer to a broader parent directory
 
 ## Running With Docker Compose
 
@@ -154,6 +156,19 @@ Verify API readiness:
 ```powershell
 Invoke-WebRequest -Uri http://localhost:8080/health
 ```
+
+Verify source-boundary configuration:
+
+- confirm `STRATA_SOURCES` points to the narrowest host directory Strata should
+  be allowed to ingest for this deployment
+- confirm the same path is mounted into the API and indexer services as a
+  read-only bind mount in `ops/docker-compose.yml`
+- confirm the deployment does not rely on client requests to supply filesystem
+  paths or widen ingestion scope
+- confirm the configured directory does not depend on symlink or reparse-point
+  traversal to reach required content until deeper boundary hardening work lands
+- confirm the running stack does not need broader host filesystem access than
+  the declared source root
 
 Smoke-test search:
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -38,17 +38,25 @@ Strata must only ingest and operate on explicitly configured sources.
 
 ### Rules
 
-- No traversal outside configured root paths
-- Normalize and validate all paths
-- Do not follow symlinks outside allowed boundaries
-- All ingestion must originate from declared sources
-- Source roots must be configured server-side, never supplied by clients
+- The configured source root is a core trust boundary for the deployment
+- All ingestion must begin from a declared source root and never from a
+  client-supplied filesystem path
+- Candidate paths must be normalized and validated before use
+- No traversal may resolve outside a declared source root
+- Relative paths must remain relative to the declared source root when stored or
+  returned
+- Symlinks, reparse points, or equivalent filesystem indirection must not widen
+  access beyond the declared source root
+- If boundary safety cannot be proven for a candidate path, ingestion must fail
+  closed for that path rather than widen access
 
 ### Implementation Note
 
 The current runtime already scopes ingestion to a configured root path. Full
-boundary hardening, including symlink escape handling, remains a standing
-product requirement as the ingestion engine matures.
+boundary hardening, including deeper symlink and reparse-point escape handling,
+remains a standing product requirement as the ingestion engine matures. This
+note does not weaken the rules above; it records that the product requirement is
+already set even where deeper enforcement work is still queued.
 
 ## AI-Optional Requirement
 


### PR DESCRIPTION
## Summary
- formalize the source boundary as an explicit trust boundary in the requirements and architecture docs
- document fail-closed and no-client-path rules without implying new ingestion implementation
- add operator verification guidance for source-boundary checks in operations docs

Closes #33