### PR TITLE
chore(repo): add layout baseline and build bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,16 @@
 /.idea
 /.vs
 .env
+/artifacts/
 **/bin/
 **/obj/
 **/node_modules/
 **/dist/
+*.user
+*.suo
+*.userprefs
+*.sln.ide
+.DS_Store
 # Frontend local install/build output
 src/Codex.Web/node_modules/
 src/Codex.Web/dist/

--- a/README.md
+++ b/README.md
@@ -117,6 +117,42 @@ docker compose -f ops/docker-compose.yml --env-file .env --profile ai up -d --bu
 - [`docs/adr/ADR-001-project-identity.md`](docs/adr/ADR-001-project-identity.md)
 - [`docs/adr/ADR-002-internal-rename-strategy.md`](docs/adr/ADR-002-internal-rename-strategy.md)
 
+## Repository Layout
+
+Strata now standardizes around a simple top-level layout:
+
+- `src/` for product code and runtime projects
+- `tests/` for test projects as coverage is added
+- `docs/` for product, architecture, and operations documentation
+- `build/` for repository-level build helpers and future build customizations
+- `ops/` for deployment and runtime assets such as Compose, Dockerfiles,
+  migrations, and operational validation scripts
+- `artifacts/` as the reserved generated-output location for future build and
+  packaging work
+
+Current note:
+
+- `ops/` remains separate from `build/` because its contents are deployment and
+  runtime assets, not build customizations
+- `Codex.slnx` is still the current solution file name during the internal
+  rename transition
+- empty layout placeholders do not imply finished test or packaging coverage
+
+## Build Bootstrap
+
+Use the root bootstrap scripts to run the current baseline validation flow:
+
+```powershell
+.\build.cmd
+```
+
+```bash
+./build.sh
+```
+
+These entry points are bootstrap wrappers for the current readiness validation,
+not a full packaging pipeline yet.
+
 ## Roadmap
 
 - Milestone 2: source-aware ingestion and source-boundary hardening

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,14 @@
+@echo off
+setlocal
+
+set "RepoRoot=%~dp0"
+set "ValidationScript=%RepoRoot%ops\validate-platform-readiness.ps1"
+
+if not exist "%ValidationScript%" (
+  echo Expected validation script at "%ValidationScript%".
+  exit /b 1
+)
+
+echo Running Strata baseline validation bootstrap...
+powershell -ExecutionPolicy Bypass -File "%ValidationScript%"
+exit /b %ERRORLEVEL%

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+web_root="$repo_root/src/Codex.Web"
+compose_file="$repo_root/ops/docker-compose.yml"
+env_file="$repo_root/.env"
+api_url="${STRATA_BUILD_API_URL:-http://127.0.0.1:5180}"
+
+run_step() {
+  local name="$1"
+  shift
+
+  echo "==> $name"
+  "$@"
+  echo "OK: $name"
+}
+
+install_web_dependencies() {
+  (
+    cd "$web_root"
+    npm install
+  )
+}
+
+build_web_shell() {
+  (
+    cd "$web_root"
+    npm run build
+  )
+}
+
+probe_api_readiness() {
+  local api_pid
+  local api_log
+  api_log="$(mktemp)"
+
+  cleanup() {
+    if [[ -n "${api_pid:-}" ]] && kill -0 "$api_pid" 2>/dev/null; then
+      kill "$api_pid"
+      wait "$api_pid" || true
+    fi
+
+    rm -f "$api_log"
+  }
+
+  trap cleanup RETURN
+
+  (
+    cd "$repo_root"
+    ASPNETCORE_ENVIRONMENT=Development \
+    ASPNETCORE_URLS="$api_url" \
+    Codex__DocsRootPath="$repo_root/docs" \
+    ConnectionStrings__Default="Host=localhost;Port=5432;Database=strata;Username=strata;Password=strata" \
+    dotnet run --project src/Codex.Api/Codex.Api.csproj --no-build --no-launch-profile
+  ) >"$api_log" 2>&1 &
+  api_pid=$!
+
+  for _ in $(seq 1 30); do
+    if curl --fail --silent "$api_url/health" >/dev/null; then
+      return 0
+    fi
+
+    if ! kill -0 "$api_pid" 2>/dev/null; then
+      cat "$api_log"
+      echo "API process exited before readiness succeeded." >&2
+      return 1
+    fi
+
+    sleep 2
+  done
+
+  cat "$api_log"
+  echo "API readiness probe did not succeed at $api_url/health." >&2
+  return 1
+}
+
+echo "Running Strata baseline validation bootstrap..."
+
+run_step "Build .NET solution" dotnet build "$repo_root/Codex.slnx"
+
+run_step "Install web dependencies" install_web_dependencies
+run_step "Build web shell" build_web_shell
+
+if [[ ! -f "$env_file" ]]; then
+  echo "Expected repository-root .env for Compose validation." >&2
+  exit 1
+fi
+
+run_step "Validate Docker Compose config" docker compose -f "$compose_file" --env-file "$env_file" config
+run_step "Probe API readiness" probe_api_readiness
+
+echo "Platform readiness validation passed."

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,16 @@
+# Build Folder
+
+`build/` is reserved for repository-level build helpers and future build
+customizations.
+
+Current state:
+
+- `build.cmd` is the Windows bootstrap entry point for the baseline validation
+  flow
+- `build.sh` is the Unix-like shell bootstrap entry point for the same baseline
+  flow
+- the main validation logic still lives in `ops/validate-platform-readiness.ps1`
+  while the repo remains early and narrowly scoped
+
+This folder exists now so Strata can standardize its top-level layout before
+broader build and packaging work lands.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,12 @@
+# Tests Folder
+
+`tests/` is the reserved home for automated test projects.
+
+Current state:
+
+- the repository does not yet have committed test projects
+- Milestone 1 and later issues will add focused test suites here as retrieval,
+  ingestion, and access-control coverage expands
+
+This placeholder keeps the intended repository layout explicit without implying
+that broad automated coverage already exists today.


### PR DESCRIPTION
## Summary
- document the standard top-level repository layout and keep `ops/` separate from build customizations
- add `build.cmd` and `build.sh` as lightweight bootstrap entry points for the current baseline validation flow
- reserve `build/`, `tests/`, and `artifacts/` expectations without overstating current packaging or test coverage

## Validation
- `git diff --check`
- `./build.cmd`
- `bash -n build.sh` via Git Bash

Closes #123