### PR TITLE
chore(ops): add structured runtime logging

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -218,6 +218,35 @@ GitHub Actions runs the same baseline validation on pull requests and pushes to
 `main` through
 `.github/workflows/validate-platform-readiness.yml`.
 
+## Runtime Logs
+
+Strata now emits structured JSON console logs for the API and indexer so local
+and container logs can be reviewed consistently.
+
+Current logging intent:
+
+- retrieval logs include request context such as trace id, request path, method,
+  request outcome, and safe request metadata like query length or result count
+- ingestion logs include worker id, job id, configured source root, lifecycle
+  events, sync counts, and failure details
+- document content and raw search query text should not be logged as part of
+  routine retrieval diagnostics
+
+Local verification:
+
+```powershell
+docker compose -f ops/docker-compose.yml --env-file .env logs --tail 100 api
+docker compose -f ops/docker-compose.yml --env-file .env logs --tail 100 indexer
+```
+
+What to confirm:
+
+- API log entries are JSON-shaped and include scoped request fields for search,
+  document reads, and index-job operations
+- indexer log entries are JSON-shaped and include worker and job context for job
+  claim, sync, completion, and failure paths
+- retrieval diagnostics do not include full document content or raw query text
+
 ## Web Shell
 
 The current web shell runs on Next.js and continues to call the Strata API

--- a/src/Codex.Api/Controllers/DocumentsController.cs
+++ b/src/Codex.Api/Controllers/DocumentsController.cs
@@ -6,7 +6,9 @@ namespace Codex.Api.Controllers;
 
 [ApiController]
 [Route("api/documents")]
-public sealed class DocumentsController(DocumentsStore store) : ControllerBase
+public sealed class DocumentsController(
+    DocumentsStore store,
+    ILogger<DocumentsController> logger) : ControllerBase
 {
     [HttpGet("{id:long}")]
     [ProducesResponseType<DocumentResponse>(StatusCodes.Status200OK)]
@@ -15,8 +17,23 @@ public sealed class DocumentsController(DocumentsStore store) : ControllerBase
         [FromRoute] long id,
         CancellationToken cancellationToken)
     {
+        using var scope = logger.BeginScope(
+            new Dictionary<string, object?>
+            {
+                ["TraceId"] = HttpContext.TraceIdentifier,
+                ["RequestPath"] = HttpContext.Request.Path.Value,
+                ["RequestMethod"] = HttpContext.Request.Method,
+                ["DocumentId"] = id
+            });
+
         var document = await store.GetByIdAsync(id, cancellationToken);
-        // Missing ids map to 404 for viewer callers.
-        return document is null ? NotFound() : Ok(document);
+        if (document is null)
+        {
+            logger.LogWarning("Document lookup returned no result.");
+            return NotFound();
+        }
+
+        logger.LogInformation("Returned document response.");
+        return Ok(document);
     }
 }

--- a/src/Codex.Api/Controllers/IndexJobsController.cs
+++ b/src/Codex.Api/Controllers/IndexJobsController.cs
@@ -6,7 +6,9 @@ namespace Codex.Api.Controllers;
 
 [ApiController]
 [Route("api/index-jobs")]
-public sealed class IndexJobsController(IndexJobsStore store) : ControllerBase
+public sealed class IndexJobsController(
+    IndexJobsStore store,
+    ILogger<IndexJobsController> logger) : ControllerBase
 {
     [HttpPost]
     [ProducesResponseType<IndexJobResponse>(StatusCodes.Status201Created)]
@@ -14,10 +16,22 @@ public sealed class IndexJobsController(IndexJobsStore store) : ControllerBase
         [FromBody] CreateIndexJobRequest request,
         CancellationToken cancellationToken)
     {
+        using var scope = logger.BeginScope(
+            new Dictionary<string, object?>
+            {
+                ["TraceId"] = HttpContext.TraceIdentifier,
+                ["RequestPath"] = HttpContext.Request.Path.Value,
+                ["RequestMethod"] = HttpContext.Request.Method
+            });
+
         // Request is intentionally empty for Phase 1.
         _ = request;
 
         var createdJob = await store.CreatePendingJobAsync(cancellationToken);
+        logger.LogInformation(
+            "Created indexing job (job_id: {JobId}, status: {JobStatus})",
+            createdJob.Id,
+            createdJob.Status);
         return Created($"/api/index-jobs/{createdJob.Id}", createdJob);
     }
 
@@ -28,7 +42,26 @@ public sealed class IndexJobsController(IndexJobsStore store) : ControllerBase
         [FromRoute] long id,
         CancellationToken cancellationToken)
     {
+        using var scope = logger.BeginScope(
+            new Dictionary<string, object?>
+            {
+                ["TraceId"] = HttpContext.TraceIdentifier,
+                ["RequestPath"] = HttpContext.Request.Path.Value,
+                ["RequestMethod"] = HttpContext.Request.Method,
+                ["JobId"] = id
+            });
+
         var job = await store.GetJobByIdAsync(id, cancellationToken);
-        return job is null ? NotFound() : Ok(job);
+        if (job is null)
+        {
+            logger.LogWarning("Index job lookup returned no result.");
+            return NotFound();
+        }
+
+        logger.LogInformation(
+            "Returned index job status (status: {JobStatus}, worker_id: {WorkerId})",
+            job.Status,
+            job.WorkerId);
+        return Ok(job);
     }
 }

--- a/src/Codex.Api/Controllers/SearchController.cs
+++ b/src/Codex.Api/Controllers/SearchController.cs
@@ -6,7 +6,9 @@ namespace Codex.Api.Controllers;
 
 [ApiController]
 [Route("api/search")]
-public sealed class SearchController(SearchStore store) : ControllerBase
+public sealed class SearchController(
+    SearchStore store,
+    ILogger<SearchController> logger) : ControllerBase
 {
     [HttpPost]
     [ProducesResponseType<SearchResponse>(StatusCodes.Status200OK)]
@@ -15,8 +17,23 @@ public sealed class SearchController(SearchStore store) : ControllerBase
         [FromBody] SearchRequest request,
         CancellationToken cancellationToken)
     {
+        var queryLength = request.Query?.Length ?? 0;
+        var remoteIp = HttpContext.Connection.RemoteIpAddress?.ToString();
+        using var scope = logger.BeginScope(
+            new Dictionary<string, object?>
+            {
+                ["TraceId"] = HttpContext.TraceIdentifier,
+                ["RequestPath"] = HttpContext.Request.Path.Value,
+                ["RequestMethod"] = HttpContext.Request.Method,
+                ["RemoteIp"] = remoteIp
+            });
+
         if (string.IsNullOrWhiteSpace(request.Query))
         {
+            logger.LogWarning(
+                "Rejected search request because the query was empty (query_length: {QueryLength}, requested_limit: {RequestedLimit})",
+                queryLength,
+                request.Limit);
             ModelState.AddModelError(nameof(request.Query), "Query must not be empty.");
             return ValidationProblem(ModelState);
         }
@@ -27,6 +44,11 @@ public sealed class SearchController(SearchStore store) : ControllerBase
         var limit = Math.Clamp(request.Limit, 1, 50);
 
         var results = await store.SearchAsync(query, limit, cancellationToken);
+        logger.LogInformation(
+            "Completed search request (query_length: {QueryLength}, result_limit: {ResultLimit}, result_count: {ResultCount})",
+            query.Length,
+            limit,
+            results.Count);
         return Ok(new SearchResponse(query, limit, results));
     }
 }

--- a/src/Codex.Api/Program.cs
+++ b/src/Codex.Api/Program.cs
@@ -4,7 +4,12 @@ using Npgsql;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
+builder.Logging.ClearProviders();
+builder.Logging.AddJsonConsole(options =>
+{
+    options.IncludeScopes = true;
+    options.TimestampFormat = "O";
+});
 
 builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi

--- a/src/Codex.Indexer/Program.cs
+++ b/src/Codex.Indexer/Program.cs
@@ -6,6 +6,13 @@ using Npgsql;
 
 var builder = Host.CreateApplicationBuilder(args);
 
+builder.Logging.ClearProviders();
+builder.Logging.AddJsonConsole(options =>
+{
+    options.IncludeScopes = true;
+    options.TimestampFormat = "O";
+});
+
 var docsRoot = builder.Configuration["Codex:DocsRoot"];
 if (string.IsNullOrWhiteSpace(docsRoot))
 {

--- a/src/Codex.Indexer/Worker.cs
+++ b/src/Codex.Indexer/Worker.cs
@@ -1,6 +1,7 @@
 using Codex.Indexer.Configuration;
 using Codex.Indexer.Data;
 using Codex.Indexer.Indexing;
+using System.Diagnostics;
 
 namespace Codex.Indexer;
 
@@ -17,9 +18,10 @@ public sealed class Worker(
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         logger.LogInformation(
-            "Codex.Indexer started (worker_id: {WorkerId}, docs_root: {DocsRoot})",
+            "Codex.Indexer started (worker_id: {WorkerId}, docs_root: {DocsRoot}, poll_interval_seconds: {PollIntervalSeconds})",
             _workerId,
-            settings.DocsRoot);
+            settings.DocsRoot,
+            _pollInterval.TotalSeconds);
 
         while (!stoppingToken.IsCancellationRequested)
         {
@@ -33,7 +35,11 @@ public sealed class Worker(
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Unhandled error in polling loop.");
+                logger.LogError(
+                    ex,
+                    "Unhandled error in polling loop (worker_id: {WorkerId}, docs_root: {DocsRoot})",
+                    _workerId,
+                    settings.DocsRoot);
                 await Task.Delay(_pollInterval, stoppingToken);
             }
         }
@@ -51,14 +57,26 @@ public sealed class Worker(
             await indexJobsStore.ClaimNextPendingJobAsync(_workerId, cancellationToken);
         if (claimedJob is null)
         {
+            logger.LogDebug(
+                "No pending index job found (worker_id: {WorkerId}, poll_interval_seconds: {PollIntervalSeconds})",
+                _workerId,
+                _pollInterval.TotalSeconds);
             await Task.Delay(_pollInterval, cancellationToken);
             return;
         }
 
+        using var loggingScope = logger.BeginScope(
+            new Dictionary<string, object?>
+            {
+                ["WorkerId"] = _workerId,
+                ["JobId"] = claimedJob.Id,
+                ["DocsRoot"] = settings.DocsRoot
+            });
+        var stopwatch = Stopwatch.StartNew();
+
         // Claiming commits in the store before this point, so processing is lock-free.
         logger.LogInformation(
-            "Claimed index job {JobId} (attempt {AttemptCount}/{MaxAttempts})",
-            claimedJob.Id,
+            "Claimed index job for processing (attempt_count: {AttemptCount}, max_attempts: {MaxAttempts})",
             claimedJob.AttemptCount,
             claimedJob.MaxAttempts);
 
@@ -66,9 +84,10 @@ public sealed class Worker(
         {
             await ProcessClaimedJobAsync(claimedJob, documentsStore, cancellationToken);
             await indexJobsStore.MarkJobCompletedAsync(claimedJob.Id, cancellationToken);
+            stopwatch.Stop();
             logger.LogInformation(
-                "Completed index job {JobId} on attempt {AttemptCount}/{MaxAttempts}",
-                claimedJob.Id,
+                "Completed index job (duration_ms: {DurationMs}, attempt_count: {AttemptCount}, max_attempts: {MaxAttempts})",
+                stopwatch.ElapsedMilliseconds,
                 claimedJob.AttemptCount,
                 claimedJob.MaxAttempts);
         }
@@ -86,25 +105,31 @@ public sealed class Worker(
                     claimedJob.Id,
                     errorMessage,
                     cancellationToken);
+            stopwatch.Stop();
 
             if (failureDisposition.WillRetry)
             {
                 logger.LogWarning(
                     ex,
-                    "Index job {JobId} failed on attempt {AttemptCount}/{MaxAttempts}; " +
-                    "returned to pending for retry.",
-                    claimedJob.Id,
+                    "Index job failed and returned to pending for retry " +
+                    "(duration_ms: {DurationMs}, attempt_count: {AttemptCount}, " +
+                    "max_attempts: {MaxAttempts}, error_message: {ErrorMessage})",
+                    stopwatch.ElapsedMilliseconds,
                     failureDisposition.AttemptCount,
-                    failureDisposition.MaxAttempts);
+                    failureDisposition.MaxAttempts,
+                    errorMessage);
             }
             else
             {
                 logger.LogError(
                     ex,
-                    "Index job {JobId} failed on final attempt {AttemptCount}/{MaxAttempts}",
-                    claimedJob.Id,
+                    "Index job failed on final attempt " +
+                    "(duration_ms: {DurationMs}, attempt_count: {AttemptCount}, " +
+                    "max_attempts: {MaxAttempts}, error_message: {ErrorMessage})",
+                    stopwatch.ElapsedMilliseconds,
                     failureDisposition.AttemptCount,
-                    failureDisposition.MaxAttempts);
+                    failureDisposition.MaxAttempts,
+                    errorMessage);
             }
         }
     }
@@ -119,22 +144,24 @@ public sealed class Worker(
         // Phase 1 behavior: verify server-configured docs root before marking job complete.
         if (!Directory.Exists(settings.DocsRoot))
         {
+            logger.LogError(
+                "Configured docs root was missing before scan began (docs_root: {DocsRoot})",
+                settings.DocsRoot);
             throw new DirectoryNotFoundException(
                 $"Configured docs root '{settings.DocsRoot}' does not exist.");
         }
 
+        logger.LogInformation("Scanning configured docs root for markdown content.");
         var scannedDocuments = await scanner.ScanAsync(settings.DocsRoot, cancellationToken);
         var syncResult =
             await documentsStore.SyncDocumentsAsync(scannedDocuments, cancellationToken);
 
         logger.LogInformation(
-            "Synced markdown documents for job {JobId}: scanned {ScannedCount}, upserted " +
-            "{UpsertedCount}, deleted {DeletedCount}",
-            claimedJob.Id,
+            "Synced markdown documents (scanned_count: {ScannedCount}, upserted_count: {UpsertedCount}, deleted_count: {DeletedCount})",
             syncResult.ScannedCount,
             syncResult.UpsertedCount,
             syncResult.DeletedCount);
 
-        logger.LogDebug("Processed indexing work for job {JobId}.", claimedJob.Id);
+        logger.LogDebug("Finished indexing work for claimed job.");
     }
 }


### PR DESCRIPTION
## Summary
- configure the API and indexer to emit structured JSON console logs
- add retrieval-side logging with request context and safe diagnostics that avoid logging raw document content or query text
- enrich indexer job lifecycle logs with worker, job, sync, and failure context and document local verification in operations docs

## Validation
- `dotnet build Codex.slnx`
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File ops/validate-platform-readiness.ps1`
- spot-checked structured JSON output from the indexer startup path locally

Closes #92